### PR TITLE
Update golang to 1.23.3

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,7 +13,7 @@ kube-rbac-proxy-watcher:
             We use gosec for sast scanning, see attached log.
     steps:
       verify:
-        image: 'golang:1.23.2'
+        image: 'golang:1.23.3'
     traits:
       version:
         preprocess: "inject-commit-hash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Stage 1: Build the Go app
-FROM golang:1.23.2 AS build
+FROM golang:1.23.3 AS build
 
 # Set up the working directory
 WORKDIR /src


### PR DESCRIPTION
This PR brings golang v1.23.3.

```other developer
golang is updated to v1.23.3
```
