### PR TITLE
chore(deps): bump up kube-rbac-proxy to 0.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 RUN make watcher
 
 # Stage 2: Produce the runtime image
-FROM quay.io/brancz/kube-rbac-proxy:v0.18.2 AS watcher
+FROM quay.io/brancz/kube-rbac-proxy:v0.19.0 AS watcher
 
 # Copy the binary from the build stage
 COPY --from=build /go/src/build/watcher /usr/bin/watcher


### PR DESCRIPTION
This PR brings the latest released version of kube-rbac-proxy.

- [kube-rbac-proxy 0.19.0](https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.19.0)
```feature user
The kube-rbac-proxy is now updated to 0.19.0
```
