### PR TITLE
bump up golang to 1.24.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Test
       run: |
         go mod download
-        go tool gotestsum ./...
+        go tool gotestsum --format github-actions

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Stage 1: Build the Go app
-FROM golang:1.24.0 AS build
+FROM golang:1.24.1 AS build
 
 WORKDIR /go/src
 # Copy the source code into the container

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kube-rbac-proxy-watcher
 
-go 1.24.0
+go 1.24.1
 
 tool (
 	github.com/golangci/golangci-lint/cmd/golangci-lint


### PR DESCRIPTION
This PR bumps up Golang to 1.24.1.

```other developer
Going is updated to 1.24.1
```
