### PR TITLE
build: bump up golang to 1.24.1 in ci

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,7 +13,7 @@ kube-rbac-proxy-watcher:
             We use gosec for sast scanning, see attached log.
     steps:
       verify:
-        image: 'golang:1.24.0'
+        image: 'golang:1.24.1'
     traits:
       version:
         preprocess: "inject-commit-hash"


### PR DESCRIPTION
This PR bumps up golang in verify ci step.

```other developer
None
```
