### PR TITLE
Update golang to 1.24.2

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,7 +13,7 @@ kube-rbac-proxy-watcher:
             We use gosec for sast scanning, see attached log.
     steps:
       verify:
-        image: 'golang:1.24.1'
+        image: 'golang:1.24.2'
     traits:
       version:
         preprocess: "inject-commit-hash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Stage 1: Build the Go app
-FROM golang:1.24.1 AS build
+FROM golang:1.24.2 AS build
 
 WORKDIR /go/src
 # Copy the source code into the container

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kube-rbac-proxy-watcher
 
-go 1.24.1
+go 1.24.2
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint


### PR DESCRIPTION
This PR brings go 1.24.2 to the project.

The updates include:
- build container image
- CI pipeline
- go.mod

`go 1.24.2` - [release notes](https://groups.google.com/g/golang-announce/c/Y2uBTVKjBQk/m/cs_6qIK5BAAJ)

```other developer
"go" is updated to 1.24.2
```
