### PR TITLE
Enhance golangci-lint setup

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,10 +3,17 @@ run:
   concurrency: 4
   go: "1.24"
 linters:
+  default: none # standard/all/none/fast
   enable:
+    - errcheck
+    - gocritic
+    - govet
+    - nlreturn
     - revive
-  disable:
+    - staticcheck
     - unused
+    - whitespace
+    - wsl
   exclusions:
     generated: lax
     rules:
@@ -27,13 +34,14 @@ linters:
       - path: (.+)\.go$
         text: '".*" imported but not used'
     paths:
-      - third_party$
-      - builtin$
-      - examples$
+      - hack/.*
 formatters:
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(kube-rbac-proxy-watcher)

--- a/cmd/parameters/parameters.go
+++ b/cmd/parameters/parameters.go
@@ -73,5 +73,6 @@ func indexOf(params []string, str string) int {
 			return i
 		}
 	}
+
 	return -1
 }

--- a/cmd/parameters/parameters.go
+++ b/cmd/parameters/parameters.go
@@ -56,6 +56,7 @@ func Parse(params []string) Parameters {
 	if cmdLineIndex != -1 && cmdLineIndex < len(params) {
 		cmdLineStr := strings.TrimPrefix(params[cmdLineIndex], cmdLineParam)
 		parameters.CmdLine = cmdLineStr
+
 		if watchedDirIndex > cmdLineIndex {
 			parameters.CmdLineArgs = params[cmdLineIndex+1 : watchedDirIndex]
 		} else {

--- a/cmd/parameters/parameters.go
+++ b/cmd/parameters/parameters.go
@@ -24,7 +24,6 @@ type Parameters struct {
 
 // Parse returns the parameters based on the supplied arguments
 func Parse(params []string) Parameters {
-
 	parameters := Parameters{
 		CmdLine:     defaultCmdLine,
 		CmdLineArgs: []string{},

--- a/cmd/parameters/parametes_test.go
+++ b/cmd/parameters/parametes_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestParams(t *testing.T) {
-
 	tests := []struct {
 		input    []string
 		expected Parameters
@@ -33,5 +32,4 @@ func TestParams(t *testing.T) {
 		t.Logf("running test %d", i)
 		assert.EqualValues(t, test.expected, Parse(test.input))
 	}
-
 }

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -41,7 +41,6 @@ func init() {
 // hot configuration reload and needs to be restarted to reflect on configuration changes.
 
 func main() {
-
 	params := parameters.Parse(os.Args)
 	log.Info(
 		"child process parameters",
@@ -104,5 +103,4 @@ func main() {
 			}
 		}
 	}
-
 }

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -50,11 +50,11 @@ func main() {
 	)
 
 	proc = process.New(log, params.CmdLine, params.CmdLineArgs...)
-
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	done := make(chan bool, 1)
 
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	done := make(chan bool, 1)
 	c, cancel := context.WithCancel(context.Background())
 	ctx := logr.NewContext(c, log)
 
@@ -64,7 +64,9 @@ func main() {
 			"signal received",
 			"signal", sig.String(),
 		)
+
 		_ = proc.Stop()
+
 		done <- true
 	}()
 
@@ -90,12 +92,16 @@ func main() {
 					"old hash", currentHash,
 					"new hash", h,
 				)
+
 				currentHash = h
+
 				if err := proc.Stop(); err != nil {
 					log.Error(err, "error stopping child process")
 					os.Exit(1)
 				}
+
 				proc = process.New(log, params.CmdLine, params.CmdLineArgs...)
+
 				if err := proc.Start(); err != nil {
 					log.Error(err, "error starting child process")
 					os.Exit(1)

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -72,7 +72,7 @@ func main() {
 	hash := watcher.RunTotalHashCalc(ctx, params.WatchedDir)
 	currentHash := <-hash
 
-	//Shall start the processes and maintain the PID
+	// Shall start the processes and maintain the PID
 	if err := proc.Start(); err != nil {
 		log.Error(err, "error starting the child process")
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module kube-rbac-proxy-watcher
 go 1.24.2
 
 tool (
+	github.com/daixiang0/gci
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/google/addlicense
-	github.com/incu6us/goimports-reviser/v3
 	github.com/onsi/ginkgo/v2/ginkgo
 	github.com/securego/gosec/v2/cmd/gosec
-	golang.org/x/tools/cmd/goimports
 	gotest.tools/gotestsum
 )
 
@@ -126,7 +125,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/incu6us/goimports-reviser/v3 v3.8.2 // indirect
 	github.com/jgautheron/goconst v1.7.1 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect
 	github.com/jjti/go-spancheck v0.6.4 // indirect
@@ -229,7 +227,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,6 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/incu6us/goimports-reviser/v3 v3.8.2 h1:OYs6hqJ3oaAR0X7jMszIM/tcxMw2l/gkB2C/VGcItdE=
-github.com/incu6us/goimports-reviser/v3 v3.8.2/go.mod h1:r0jYpyePwPYiqxl4qjZ0xZgVEPKS/ePqVCT3XNuwR54=
 github.com/jgautheron/goconst v1.7.1 h1:VpdAG7Ca7yvvJk5n8dMwQhfEZJh95kl/Hl9S1OI5Jkk=
 github.com/jgautheron/goconst v1.7.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjzq7gFzUs=

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -36,7 +36,6 @@ func New(log logr.Logger, cmdLine string, args ...string) *Process {
 
 // Start the child process
 func (p *Process) Start() error {
-
 	if err := p.Cmd.Start(); err != nil {
 		return err
 	}
@@ -48,7 +47,6 @@ func (p *Process) Start() error {
 
 // Stop the child process
 func (p *Process) Stop() error {
-
 	p.log.Info("Send SIGINT signal", "pid", p.Process.Pid)
 
 	err := p.Process.Signal(syscall.SIGINT)

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -42,6 +42,7 @@ func (p *Process) Start() error {
 	}
 
 	p.log.Info("Start", "process", p.String(), "pid", p.Process.Pid)
+
 	return nil
 }
 
@@ -63,12 +64,15 @@ func (p *Process) Stop() error {
 	select {
 	case <-time.After(terminationTimeout):
 		p.log.Info("Timeout exceeded, sending SIGKILL signal")
+
 		return p.Process.Kill()
 	case err := <-done:
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			p.log.Error(err, "Process exited", "pid", p.Process.Pid, "exitCode", exitErr.ExitCode())
+
 			return nil
 		}
+
 		return err
 	}
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -106,7 +106,7 @@ func getFileSha256(filePath string) string {
 	file, err := os.Open(filepath.Clean(filePath))
 	if err != nil {
 		log.Error(err, "Failed to open file", "filePath", filePath)
-		
+
 		return ""
 	}
 	defer func() {

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -39,10 +39,12 @@ func RunTotalHashCalc(ctx context.Context, watchedDir string) <-chan string {
 				result <- getTotalHash(watchedDir)
 			case <-ctx.Done():
 				close(result)
+
 				return
 			}
 		}
 	}()
+
 	return result
 }
 
@@ -53,6 +55,7 @@ func getTotalHash(watchedDir string) string {
 	dir, err := os.ReadDir(watchedDir)
 	if err != nil {
 		log.Error(err, "Failed to read watched directory")
+
 		return ""
 	}
 
@@ -75,6 +78,7 @@ func getTotalHash(watchedDir string) string {
 	var fileHashes []string
 	filesMap.Range(func(_, value interface{}) bool {
 		fileHashes = append(fileHashes, value.(string))
+
 		return true
 	})
 	sort.Strings(fileHashes)
@@ -90,16 +94,19 @@ func getFileSha256(filePath string) string {
 
 	if err != nil {
 		log.Error(err, "Failed to retrieve file stats", "filePath", filePath)
+
 		return ""
 	}
 	if stat.IsDir() {
 		log.V(9).Info("Skipping directory", "filePath", filePath)
+
 		return ""
 	}
 
 	file, err := os.Open(filepath.Clean(filePath))
 	if err != nil {
 		log.Error(err, "Failed to open file", "filePath", filePath)
+		
 		return ""
 	}
 	defer func() {
@@ -111,6 +118,7 @@ func getFileSha256(filePath string) string {
 	hash := sha256.New()
 	if _, err = io.Copy(hash, file); err != nil {
 		log.Error(err, "Failed to compute hash", "filePath", filePath)
+
 		return ""
 	}
 

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -33,6 +33,7 @@ func RunTotalHashCalc(ctx context.Context, watchedDir string) <-chan string {
 
 	go func() {
 		defer ticker.Stop()
+
 		for {
 			select {
 			case <-ticker.C:
@@ -62,9 +63,12 @@ func getTotalHash(watchedDir string) string {
 	// Compute hashes in parallel
 	for _, file := range dir {
 		wg.Add(1)
+
 		go func(fileName string) {
 			defer wg.Done()
+
 			filePath := filepath.Join(watchedDir, fileName)
+
 			if hash := getFileSha256(filePath); hash != "" {
 				filesMap.Store(filePath, hash)
 			}
@@ -76,6 +80,7 @@ func getTotalHash(watchedDir string) string {
 
 	// Combine hashes in sorted order
 	var fileHashes []string
+
 	filesMap.Range(func(_, value interface{}) bool {
 		fileHashes = append(fileHashes, value.(string))
 
@@ -96,6 +101,7 @@ func getFileSha256(filePath string) string {
 
 		return ""
 	}
+
 	if stat.IsDir() {
 		log.V(9).Info("Skipping directory", "filePath", filePath)
 
@@ -108,6 +114,7 @@ func getFileSha256(filePath string) string {
 
 		return ""
 	}
+
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
 			log.Error(closeErr, "Failed to close file", "filePath", filePath)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -89,7 +89,6 @@ func getTotalHash(watchedDir string) string {
 }
 
 func getFileSha256(filePath string) string {
-
 	stat, err := os.Stat(filePath)
 
 	if err != nil {

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -22,6 +22,7 @@ func TestWatcher(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(tmp, "f1.tmp"), []byte("Hello World"), 0444); err != nil {
 		t.Errorf("cannot write temporary file: %v", err)
 	}
+
 	if err := os.WriteFile(filepath.Join(tmp, "f2.tmp"), []byte("World Hello"), 0444); err != nil {
 		t.Errorf("cannot write temporary file: %v", err)
 	}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -34,5 +34,4 @@ func TestWatcher(t *testing.T) {
 	assert.Equal(t, expected, <-RunTotalHashCalc(ctx, tmp))
 
 	defer cancel()
-
 }

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -29,7 +29,7 @@ func TestWatcher(t *testing.T) {
 	c, cancel := context.WithCancel(context.Background())
 	ctx := logr.NewContext(c, log)
 
-	//file hash can be calculated with
+	// File hash can be calculated with
 	expected := "6e65973b642de59b523dbb45c725fa3875491c469fa63def52aa51f8477cb087"
 	assert.Equal(t, expected, <-RunTotalHashCalc(ctx, tmp))
 


### PR DESCRIPTION
This PR adds linters and formatters to the projects

[golangci-lint.run](https://golangci-lint.run)

Following linters are now part of the build:
- errcheck
- gocritic
- govet
- nlreturn
- revive
- staticcheck
- unused
- whitespace
- wsl 

Following formatters are now part of the build:
- gci
- gofmt



```feature developer
The project build now features an extended set of linters.
```
