### PR TITLE
Apply auto inesrt summary only when the pr description is empty

### DIFF
--- a/.hyperspace/pull_request_bot.json
+++ b/.hyperspace/pull_request_bot.json
@@ -10,7 +10,7 @@
       "use_tabular_summarize_output_template": false
     },
     "review": {
-      "auto_generate_review": true,
+      "auto_generate_review": false,
       "use_custom_review_focus": false
     }
   }

--- a/.hyperspace/pull_request_bot_summarize_prompt.md
+++ b/.hyperspace/pull_request_bot_summarize_prompt.md
@@ -1,6 +1,6 @@
 # PR Summarization Prompt
 
-Apply this prompt to summarize pull requests only when the PR description is empty.
+"auto_insert_summary" only applies when the PR description is empty.
 
 Summarize the changes in this pull request for a technical audience.
 Highlight the main features and improvements in one paragraph - required.


### PR DESCRIPTION
**How to categorize this PR?**
/kind cleanup
/area logging

**What this PR does / why we need it**:
This PR updates the pull request bot configuration to improve the automated summary behavior. The main change disables automatic review generation while keeping the summary feature enabled, and clarifies the documentation to specify that auto-insertion of summaries only occurs when the PR description is empty.

**Code changes**:
- Modified `.hyperspace/pull_request_bot.json` to set `auto_generate_review` to `false`
- Updated `.hyperspace/pull_request_bot_summarize_prompt.md` to clarify that "auto_insert_summary" only applies when the PR description is empty

**Additional context**:
These changes optimize the pull request bot's behavior by focusing on summary generation while reducing unnecessary automated reviews, and provide clearer documentation about when summaries are automatically inserted.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This is a configuration change that affects the automated PR bot behavior. Please verify that disabling auto-review generation aligns with the team's workflow preferences.

**Release note**:
```other developer
NONE
```

- [ ] 🔄 Regenerate Summary

