### PR TITLE
Bump component and golang runtime versions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# kube-ebac-proxy-watcher
-* @nickytd
+# kube-rbac-proxy-watcher
+* @bobi-wan

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Stage 1: Build the Go app
-FROM golang:1.26.2 AS build
+FROM golang:1.26.4 AS build
 
 WORKDIR /go/src
 # Copy the source code into the container
@@ -14,7 +14,7 @@ RUN go mod download
 RUN make watcher
 
 # Stage 2: Produce the runtime image
-FROM quay.io/brancz/kube-rbac-proxy:v0.21.2 AS watcher
+FROM quay.io/brancz/kube-rbac-proxy:v0.22.0 AS watcher
 
 # Copy the binary from the build stage
 COPY --from=build /go/src/build/watcher /usr/bin/watcher


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
version bump: bump quay.io/brancz/kube-rbac-proxy to 0.22.0 and docker image golang runtime to 1.26.4
Done for security fixes

Also updates CODEOWNERS file to match current responsibilities.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Component and container golang runtime version bump.
```
